### PR TITLE
docs: Add documentation for cpu and memory variables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,8 @@ Optional variables:
 - `priority`: Traefik routing priority (default: 2000)
 - `assets_paths`: List of asset paths for separate routing (e.g., `["/_next/", "/favicon.ico", "/robots.txt", "/static/"]`)
 - `assets_priority`: Priority for assets router (default: priority + 1000)
+- `cpu`: CPU allocation per replica (default: "0.25")
+- `memory`: Memory allocation per replica (default: "64M")
 
 ## Infrastructure Features
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ ansible-playbook -i inventory.ini playbooks/add-service.yaml --extra-vars @vars/
 - `priority`: Traefik routing priority (default: 2000)
 - `assets_paths`: List of asset paths for separate routing
 - `assets_priority`: Priority for assets router (default: priority + 1000)
+- `cpu`: CPU allocation per replica (default: "0.25")
+- `memory`: Memory allocation per replica (default: "64M")
 
 ### Updating Services
 

--- a/vars/example.yaml
+++ b/vars/example.yaml
@@ -4,6 +4,8 @@ port: 3000
 host: yourdomain.com
 path: /apps
 replicas: 1
+# cpu: "1" # CPU allocation per replica (default: 0.25)
+# memory: "256M" # Memory allocation per replica (default: 64M)
 # Registry authentication (optional)
 registry_url: ghcr.io
 registry_username: your_username


### PR DESCRIPTION
The Ansible role for services already supported `cpu` and `memory` allocation, but this was undocumented.

This commit adds documentation for these variables to `README.md` and `CLAUDE.md`, and adds commented-out examples to `vars/example.yaml`.