### PR TITLE
feat(service): Allow custom config path and command

### DIFF
--- a/roles/service/tasks/add.yaml
+++ b/roles/service/tasks/add.yaml
@@ -14,7 +14,10 @@
   when: service_config is defined
 - name: Set config name
   ansible.builtin.set_fact:
-    service_config_name: "{{ service_config_name_override | default(name ~ '_config_' ~ (service_config | to_nice_yaml | hash('sha1') | truncate(12, True, ''))) }}"
+    service_config_name: "{{ service_config_name_override | default(default_service_config_name) }}"
+  vars:
+    default_service_config_name: >-
+      {{ name }}_config_{{ service_config | to_nice_yaml | hash('sha1') | truncate(12, True, '') }}
   when: service_config is defined
 - name: Create docker config
   community.docker.docker_config:

--- a/roles/service/tasks/add.yaml
+++ b/roles/service/tasks/add.yaml
@@ -14,7 +14,7 @@
   when: service_config is defined
 - name: Set config name
   ansible.builtin.set_fact:
-    service_config_name: "{{ name }}_config_{{ service_config | to_nice_yaml | hash('sha1') | truncate(12, True, '') }}"
+    service_config_name: "{{ service_config_name_override | default(name ~ '_config_' ~ (service_config | to_nice_yaml | hash('sha1') | truncate(12, True, ''))) }}"
   when: service_config is defined
 - name: Create docker config
   community.docker.docker_config:

--- a/roles/service/templates/service-swarm.yaml.j2
+++ b/roles/service/templates/service-swarm.yaml.j2
@@ -14,9 +14,10 @@ services:
     image: {{ image }}
     networks: [web]
 {% if service_config is defined %}
+{%   set default_target_path = '/' + name + '.config.' + (service_config_format | default('yaml')) %}
     configs:
       - source: {{ service_config_name }}
-        target: "{{ service_config_target_path | default('/' + name + '.config.' + (service_config_format | default('yaml'))) }}"
+        target: "{{ service_config_target_path | default(default_target_path) }}"
 {% endif %}
 {% if command is defined %}
     command: /bin/sh -c "exec {{ command }}"

--- a/roles/service/templates/service-swarm.yaml.j2
+++ b/roles/service/templates/service-swarm.yaml.j2
@@ -19,7 +19,7 @@ services:
         target: "{{ service_config_target_path | default('/' + name + '.config.' + (service_config_format | default('yaml'))) }}"
 {% endif %}
 {% if command is defined %}
-    command: /bin/sh -c "exec {{ command }}{% if service_config is defined and '--config' not in command %} --config {{ service_config_target_path | default('/' + name + '.config.' + (service_config_format | default('yaml'))) }}{% endif %}"
+    command: /bin/sh -c "exec {{ command }}"
 {% endif %}
     deploy:
       replicas: {{ replicas | default(1) }}

--- a/roles/service/templates/service-swarm.yaml.j2
+++ b/roles/service/templates/service-swarm.yaml.j2
@@ -16,10 +16,10 @@ services:
 {% if service_config is defined %}
     configs:
       - source: {{ service_config_name }}
-        target: /{{ name }}.config.{{ service_config_format | default('yaml') }}
+        target: "{{ service_config_target_path | default('/' + name + '.config.' + (service_config_format | default('yaml'))) }}"
 {% endif %}
 {% if command is defined %}
-    command: /bin/sh -c "exec {{ command }}{% if service_config is defined %} --config /{{ name }}.config.{{ service_config_format | default('yaml') }}{% endif %}"
+    command: /bin/sh -c "exec {{ command }}{% if service_config is defined and '--config' not in command %} --config {{ service_config_target_path | default('/' + name + '.config.' + (service_config_format | default('yaml'))) }}{% endif %}"
 {% endif %}
     deploy:
       replicas: {{ replicas | default(1) }}


### PR DESCRIPTION
The service configuration logic was too rigid, preventing users from specifying a custom configuration file path inside the container. This was because the config path was hardcoded and the `--config` flag was always appended to the command.

This change introduces more flexibility:

- A new `service_config_target_path` variable allows specifying the exact path where the config file should be mounted inside the container.
- The `--config` flag is now only appended to the command if it's not already present, giving the user full control over the application's arguments.
- A `service_config_name_override` variable is added to allow overriding the auto-generated Docker config name, for advanced use cases.